### PR TITLE
Correct component function name for ChevronRIght

### DIFF
--- a/components/PostList/Pagination/svg/ChevronRight.js
+++ b/components/PostList/Pagination/svg/ChevronRight.js
@@ -1,4 +1,4 @@
-export default function ChevronLeft() {
+export default function ChevronRight() {
   return (
     <svg
       aria-hidden="true"


### PR DESCRIPTION
Simple change to fix the component function header. Doesn't change functionality, just a nitpick.